### PR TITLE
WL-3648 Correct the List-id in the email headers.

### DIFF
--- a/mailarchive-james/james/src/java/org/sakaiproject/james/SakaiMailet.java
+++ b/mailarchive-james/james/src/java/org/sakaiproject/james/SakaiMailet.java
@@ -505,7 +505,8 @@ public class SakaiMailet extends GenericMailet
 						M_log.warn("IOException: service(): msg.getContent() threw: " + e, e);
 					}
 					
-					mailHeaders.add("List-Id: <"+ channel.getId()+ ".localhost>");
+					mailHeaders.add("List-Id: <"+ channel.getId()+ "."+ serverConfigurationService.getServerName()+ ">");
+
 					// post the message to the group's channel
 					String body[] = new String[2];
 					body[0] = bodyBuf[0].toString(); // plain/text


### PR DESCRIPTION
Sakai has a wrong patch that means localhost gets used instead of the server hostname.
