### PR TITLE
WL-3648 Include the site ID in List-id header.

### DIFF
--- a/mailarchive-james/james/src/java/org/sakaiproject/james/SakaiMailet.java
+++ b/mailarchive-james/james/src/java/org/sakaiproject/james/SakaiMailet.java
@@ -504,8 +504,9 @@ public class SakaiMailet extends GenericMailet
 					    //e.printStackTrace();
 						M_log.warn("IOException: service(): msg.getContent() threw: " + e, e);
 					}
-					
-					mailHeaders.add("List-Id: <"+ channel.getId()+ "."+ serverConfigurationService.getServerName()+ ">");
+
+					mailHeaders.add("List-Id: <"+ channel.getId()+ "."+ channel.getContext()
+							+ "."+ serverConfigurationService.getServerName()+ ">");
 
 					// post the message to the group's channel
 					String body[] = new String[2];


### PR DESCRIPTION
The List-id: header should contain a unique value so that clients could filter on it. The channel id is just unique within a site, not across an installation.
